### PR TITLE
RVM-1127: correct use of linux only macros in bootloader

### DIFF
--- a/tools/bootloader/sysSignal_ia32.c
+++ b/tools/bootloader/sysSignal_ia32.c
@@ -752,10 +752,12 @@ EXTERNAL void dumpContext(void *context)
 #ifndef RVM_FOR_OSX
   ERROR_PRINTF("fpregs        %p\n", (void*)IA32_FPREGS(context));
 #endif
+#ifdef RVM_FOR_LINUX
 #ifndef __x86_64__
   ERROR_PRINTF("oldmask       0x%08lx\n", (unsigned long) IA32_OLDMASK(context));
   /* seems to contain mem address that faulting instruction was trying to access */
   ERROR_PRINTF("cr2           0x%08lx\n", (unsigned long) IA32_FPFAULTDATA(context));
+#endif
 #endif
 }
 


### PR DESCRIPTION
Corrects the use of linux only macros in booloader/sysSignal_ia32.c.

This fixes compilation issues under OSX and likely other targets.