### PR TITLE
Split architecture-specific functionality in BaselineCompiledMethod

### DIFF
--- a/rvm/src/org/jikesrvm/compilers/baseline/BaselineCompiler.java
+++ b/rvm/src/org/jikesrvm/compilers/baseline/BaselineCompiler.java
@@ -36,7 +36,6 @@ import org.jikesrvm.osr.BytecodeTraverser;
 import org.jikesrvm.runtime.MagicNames;
 import org.jikesrvm.runtime.Time;
 import org.jikesrvm.scheduler.RVMThread;
-import org.vmmagic.pragma.Uninterruptible;
 import org.vmmagic.unboxed.Offset;
 
 /**
@@ -77,50 +76,6 @@ public abstract class BaselineCompiler extends TemplateCompilerFramework {
    * Reference maps for method being compiled
    */
   ReferenceMaps refMaps;
-
-
-  public abstract byte getLastFixedStackRegister();
-  public abstract byte getLastFloatStackRegister();
-
-  @Uninterruptible
-  static short getGeneralLocalLocation(int localIndex, short[] localFixedLocations, NormalMethod method) {
-    if (VM.BuildForIA32) {
-      return org.jikesrvm.compilers.baseline.ia32.BaselineCompilerImpl.getGeneralLocalLocation(localIndex, localFixedLocations, method);
-    } else {
-      if (VM.VerifyAssertions) VM._assert(VM.BuildForPowerPC);
-      return org.jikesrvm.compilers.baseline.ppc.BaselineCompilerImpl.getGeneralLocalLocation(localIndex, localFixedLocations, method);
-    }
-  }
-
-  @Uninterruptible
-  static short getFloatLocalLocation(int localIndex, short[] localFixedLocations, NormalMethod method) {
-    if (VM.BuildForIA32) {
-      return org.jikesrvm.compilers.baseline.ia32.BaselineCompilerImpl.getFloatLocalLocation(localIndex, localFixedLocations, method);
-    } else {
-      if (VM.VerifyAssertions) VM._assert(VM.BuildForPowerPC);
-      return org.jikesrvm.compilers.baseline.ppc.BaselineCompilerImpl.getFloatLocalLocation(localIndex, localFixedLocations, method);
-    }
-  }
-
-  @Uninterruptible
-  static short getEmptyStackOffset(NormalMethod m) {
-    if (VM.BuildForIA32) {
-      return org.jikesrvm.compilers.baseline.ia32.BaselineCompilerImpl.getEmptyStackOffset(m);
-    } else {
-      if (VM.VerifyAssertions) VM._assert(VM.BuildForPowerPC);
-      return org.jikesrvm.compilers.baseline.ppc.BaselineCompilerImpl.getEmptyStackOffset(m);
-    }
-  }
-
-  @Uninterruptible
-  public static short offsetToLocation(int offset) {
-    if (VM.BuildForIA32) {
-      return org.jikesrvm.compilers.baseline.ia32.BaselineCompilerImpl.offsetToLocation(offset);
-    } else {
-      if (VM.VerifyAssertions) VM._assert(VM.BuildForPowerPC);
-      return org.jikesrvm.compilers.baseline.ppc.BaselineCompilerImpl.offsetToLocation(offset);
-    }
-  }
 
   protected final Offset getEdgeCounterOffset() {
     return Offset.fromIntZeroExtend(method.getId() << LOG_BYTES_IN_ADDRESS);

--- a/rvm/src/org/jikesrvm/compilers/baseline/ia32/ArchBaselineCompiledMethod.java
+++ b/rvm/src/org/jikesrvm/compilers/baseline/ia32/ArchBaselineCompiledMethod.java
@@ -1,0 +1,64 @@
+/*
+ *  This file is part of the Jikes RVM project (http://jikesrvm.org).
+ *
+ *  This file is licensed to You under the Eclipse Public License (EPL);
+ *  You may not use this file except in compliance with the License. You
+ *  may obtain a copy of the License at
+ *
+ *      http://www.opensource.org/licenses/eclipse-1.0.php
+ *
+ *  See the COPYRIGHT.txt file distributed with this work for information
+ *  regarding copyright ownership.
+ */
+package org.jikesrvm.compilers.baseline.ia32;
+
+import static org.jikesrvm.runtime.UnboxedSizeConstants.LOG_BYTES_IN_ADDRESS;
+
+import org.jikesrvm.compilers.baseline.BaselineCompiledMethod;
+import org.jikesrvm.compilers.baseline.BaselineCompiler;
+import org.jikesrvm.classloader.RVMMethod;
+import org.jikesrvm.classloader.NormalMethod;
+import org.vmmagic.pragma.Uninterruptible;
+import org.vmmagic.unboxed.Offset;
+
+/**
+ * Architecture-specific information about IA32 baseline compiled methods.
+ * Allows the location of locals and stack slots to be recovered
+ */
+public final class ArchBaselineCompiledMethod extends BaselineCompiledMethod {
+
+  public ArchBaselineCompiledMethod(int id, RVMMethod m) {
+    super(id, m);
+  }
+
+  @Override
+  protected void saveCompilerData(BaselineCompiler abstractComp) {
+    // Nothing to do on IA32
+  }
+
+  /** @return position of operand stack within method's stackframe */
+  @Uninterruptible
+  public short getEmptyStackOffset() {
+    return BaselineCompilerImpl.getEmptyStackOffset((NormalMethod)this.getMethod());
+  }
+
+  @Uninterruptible
+  private Offset getStartLocalOffset() {
+    return BaselineCompilerImpl.getStartLocalOffset((NormalMethod)this.getMethod());
+  }
+
+  @Uninterruptible
+  public short getGeneralLocalLocation(int index) {
+    return BaselineCompilerImpl.offsetToLocation(getStartLocalOffset().minus(index << LOG_BYTES_IN_ADDRESS));
+  }
+
+  @Uninterruptible
+  public short getFloatLocalLocation(int index) {
+    return BaselineCompilerImpl.offsetToLocation(getStartLocalOffset().minus(index << LOG_BYTES_IN_ADDRESS));
+  }
+
+  @Uninterruptible
+  public short getGeneralStackLocation(int stackIndex) {
+    return BaselineCompilerImpl.offsetToLocation(getEmptyStackOffset() - (stackIndex << LOG_BYTES_IN_ADDRESS));
+  }
+}

--- a/rvm/src/org/jikesrvm/compilers/baseline/ia32/BaselineCompilerImpl.java
+++ b/rvm/src/org/jikesrvm/compilers/baseline/ia32/BaselineCompilerImpl.java
@@ -73,7 +73,6 @@ import static org.jikesrvm.runtime.JavaSizeConstants.BYTES_IN_SHORT;
 import static org.jikesrvm.runtime.JavaSizeConstants.LOG_BYTES_IN_INT;
 import static org.jikesrvm.runtime.JavaSizeConstants.LOG_BYTES_IN_SHORT;
 import static org.jikesrvm.runtime.RuntimeEntrypoints.TRAP_UNREACHABLE_BYTECODE;
-import static org.jikesrvm.runtime.UnboxedSizeConstants.LOG_BYTES_IN_ADDRESS;
 
 import org.jikesrvm.VM;
 import org.jikesrvm.adaptive.AosEntrypoints;
@@ -142,10 +141,8 @@ public final class BaselineCompilerImpl extends BaselineCompiler {
    * Create a BaselineCompilerImpl object for the compilation of method.
    *
    * @param cm the method that will be associated with this compilation
-   * @param localFixedLocations unused on IA32
-   * @param localFloatLocations unused on IA32
    */
-  public BaselineCompilerImpl(BaselineCompiledMethod cm, short[] localFixedLocations, short[] localFloatLocations) {
+  public BaselineCompilerImpl(BaselineCompiledMethod cm) {
     super(cm);
     stackHeights = new int[bcodes.length()];
     parameterWords = method.getParameterWords() + (method.isStatic() ? 0 : 1); // add 1 for this pointer
@@ -171,28 +168,6 @@ public final class BaselineCompilerImpl extends BaselineCompiler {
     //nothing to do for Intel
   }
 
-  @Override
-  public byte getLastFixedStackRegister() {
-    return -1; //doesn't dedicate registers to stack;
-  }
-
-  @Override
-  public byte getLastFloatStackRegister() {
-    return -1; //doesn't dedicate registers to stack;
-  }
-
-  @Uninterruptible
-  public static short getGeneralLocalLocation(int index, short[] localloc, NormalMethod m) {
-    // we currently do not use location arrays on Intel
-    return offsetToLocation(getStartLocalOffset(m).minus(index << LOG_BYTES_IN_ADDRESS));
-  }
-
-  @Uninterruptible
-  public static short getFloatLocalLocation(int index, short[] localloc, NormalMethod m) {
-    // we currently do not use location arrays on Intel
-    return offsetToLocation(getStartLocalOffset(m).minus(index << LOG_BYTES_IN_ADDRESS));
-  }
-
   @Uninterruptible
   public static int locationToOffset(short location) {
     return -location;
@@ -210,7 +185,7 @@ public final class BaselineCompilerImpl extends BaselineCompiler {
   }
 
   @Uninterruptible
-  public static short getEmptyStackOffset(NormalMethod m) {
+  static short getEmptyStackOffset(NormalMethod m) {
     return (short)getFirstLocalOffset(m).minus(m.getLocalWords() << LG_WORDSIZE).plus(WORDSIZE).toInt();
   }
 
@@ -235,7 +210,7 @@ public final class BaselineCompilerImpl extends BaselineCompiler {
   }
 
   @Uninterruptible
-  private static Offset getStartLocalOffset(NormalMethod method) {
+  static Offset getStartLocalOffset(NormalMethod method) {
     return getFirstLocalOffset(method).plus(WORDSIZE);
   }
 

--- a/rvm/src/org/jikesrvm/compilers/baseline/ia32/BaselineGCMapIterator.java
+++ b/rvm/src/org/jikesrvm/compilers/baseline/ia32/BaselineGCMapIterator.java
@@ -33,7 +33,6 @@ import org.jikesrvm.VM;
 import org.jikesrvm.classloader.MethodReference;
 import org.jikesrvm.classloader.NormalMethod;
 import org.jikesrvm.classloader.TypeReference;
-import org.jikesrvm.compilers.baseline.BaselineCompiledMethod;
 import org.jikesrvm.compilers.baseline.ReferenceMaps;
 import org.jikesrvm.compilers.common.CompiledMethod;
 import org.jikesrvm.compilers.common.CompiledMethods;
@@ -64,7 +63,7 @@ public final class BaselineGCMapIterator extends GCMapIterator {
   /** Compiled method for the frame */
   private NormalMethod currentMethod;
   /** Compiled method for the frame */
-  private BaselineCompiledMethod currentCompiledMethod;
+  private ArchBaselineCompiledMethod currentCompiledMethod;
   private int currentNumLocals;
   /** Current index in current map */
   private int mapIndex;
@@ -141,7 +140,7 @@ public final class BaselineGCMapIterator extends GCMapIterator {
    */
   @Override
   public void setupIterator(CompiledMethod compiledMethod, Offset instructionOffset, Address fp) {
-    currentCompiledMethod = (BaselineCompiledMethod) compiledMethod;
+    currentCompiledMethod = (ArchBaselineCompiledMethod) compiledMethod;
     currentMethod = (NormalMethod) currentCompiledMethod.getMethod();
     currentNumLocals = currentMethod.getLocalWords();
 
@@ -151,7 +150,7 @@ public final class BaselineGCMapIterator extends GCMapIterator {
 
     // setup stackframe mapping
     //
-    maps = ((BaselineCompiledMethod) compiledMethod).referenceMaps;
+    maps = currentCompiledMethod.referenceMaps;
     mapId = maps.locateGCPoint(instructionOffset, currentMethod);
     mapIndex = 0;
     if (mapId < 0) {

--- a/rvm/src/org/jikesrvm/compilers/baseline/ppc/ArchBaselineCompiledMethod.java
+++ b/rvm/src/org/jikesrvm/compilers/baseline/ppc/ArchBaselineCompiledMethod.java
@@ -1,0 +1,84 @@
+/*
+ *  This file is part of the Jikes RVM project (http://jikesrvm.org).
+ *
+ *  This file is licensed to You under the Eclipse Public License (EPL);
+ *  You may not use this file except in compliance with the License. You
+ *  may obtain a copy of the License at
+ *
+ *      http://www.opensource.org/licenses/eclipse-1.0.php
+ *
+ *  See the COPYRIGHT.txt file distributed with this work for information
+ *  regarding copyright ownership.
+ */
+package org.jikesrvm.compilers.baseline.ppc;
+
+import static org.jikesrvm.runtime.UnboxedSizeConstants.LOG_BYTES_IN_ADDRESS;
+
+import org.jikesrvm.compilers.baseline.BaselineCompiledMethod;
+import org.jikesrvm.compilers.baseline.BaselineCompiler;
+import org.jikesrvm.classloader.RVMMethod;
+import org.jikesrvm.classloader.NormalMethod;
+import org.vmmagic.pragma.Uninterruptible;
+
+/**
+ * Architecture-specific information about PPC baseline compiled methods.
+ * Allows the location of registers, locals, and stack slots to be recovered
+ */
+public final class ArchBaselineCompiledMethod extends BaselineCompiledMethod {
+
+  public ArchBaselineCompiledMethod(int id, RVMMethod m) {
+    super(id, m);
+  }
+
+  private byte lastFixedStackRegister;
+  private byte lastFloatStackRegister;
+  private short[] localFixedLocations;
+  private short[] localFloatLocations;
+
+  @Override
+  protected void saveCompilerData(BaselineCompiler abstractComp) {
+    BaselineCompilerImpl comp = (BaselineCompilerImpl) abstractComp;
+
+    lastFixedStackRegister = comp.getLastFixedStackRegister();
+    lastFloatStackRegister = comp.getLastFloatStackRegister();
+    localFixedLocations = comp.getLocalFixedLocations();
+    localFloatLocations = comp.getLocalFloatLocations();
+  }
+
+  /** @return position of operand stack within method's stackframe */
+  @Uninterruptible
+  public short getEmptyStackOffset() {
+    return BaselineCompilerImpl.getEmptyStackOffset((NormalMethod)this.getMethod());
+  }
+
+  /** @return size of method's stackframe. */
+  @Uninterruptible
+  public int getFrameSize() {
+    return BaselineCompilerImpl.getFrameSize((NormalMethod)this.getMethod(), lastFloatStackRegister, lastFixedStackRegister);
+  }
+
+  @Uninterruptible
+  public byte getLastFixedStackRegister() {
+    return lastFixedStackRegister;
+  }
+
+  @Uninterruptible
+  public byte getLastFloatStackRegister() {
+    return lastFloatStackRegister;
+  }
+
+  @Uninterruptible
+  public short getGeneralLocalLocation(int index) {
+    return localFixedLocations[index];
+  }
+
+  @Uninterruptible
+  public short getFloatLocalLocation(int index) {
+    return localFloatLocations[index];
+  }
+
+  @Uninterruptible
+  public short getGeneralStackLocation(int stackIndex) {
+    return BaselineCompilerImpl.offsetToLocation(getEmptyStackOffset() - (stackIndex << LOG_BYTES_IN_ADDRESS));
+  }
+}

--- a/rvm/src/org/jikesrvm/compilers/baseline/ppc/BaselineGCMapIterator.java
+++ b/rvm/src/org/jikesrvm/compilers/baseline/ppc/BaselineGCMapIterator.java
@@ -30,7 +30,6 @@ import org.jikesrvm.VM;
 import org.jikesrvm.classloader.MethodReference;
 import org.jikesrvm.classloader.NormalMethod;
 import org.jikesrvm.classloader.TypeReference;
-import org.jikesrvm.compilers.baseline.BaselineCompiledMethod;
 import org.jikesrvm.compilers.baseline.ReferenceMaps;
 import org.jikesrvm.compilers.common.CompiledMethod;
 import org.jikesrvm.compilers.common.CompiledMethods;
@@ -72,7 +71,7 @@ public final class BaselineGCMapIterator extends GCMapIterator {
   /** method for the frame */
   private NormalMethod currentMethod;
   /** compiled method for the frame */
-  private BaselineCompiledMethod currentCompiledMethod;
+  ArchBaselineCompiledMethod currentCompiledMethod;
   private int currentNumLocals;
   /** parameter types passed by that method */
   private TypeReference[] bridgeParameterTypes;
@@ -121,7 +120,7 @@ public final class BaselineGCMapIterator extends GCMapIterator {
    */
   @Override
   public void setupIterator(CompiledMethod compiledMethod, Offset instructionOffset, Address fp) {
-    currentCompiledMethod = (BaselineCompiledMethod) compiledMethod;
+    currentCompiledMethod = (ArchBaselineCompiledMethod) compiledMethod;
     currentMethod = (NormalMethod) compiledMethod.getMethod();
     currentNumLocals = currentMethod.getLocalWords();
     // setup superclass
@@ -282,7 +281,7 @@ public final class BaselineGCMapIterator extends GCMapIterator {
       if (!bridgeRegistersLocationUpdated) {
         // point registerLocations[] to our callers stackframe
         //
-        Address location = framePtr.plus(BaselineCompilerImpl.getFrameSize(currentCompiledMethod));
+        Address location = framePtr.plus(currentCompiledMethod.getFrameSize());
         location = location.minus((LAST_NONVOLATILE_FPR.value() - FIRST_VOLATILE_FPR.value() + 1) * BYTES_IN_DOUBLE);
         // skip non-volatile and volatile fprs
         for (int i = LAST_NONVOLATILE_GPR.value(); i >= FIRST_VOLATILE_GPR.value(); --i) {
@@ -434,7 +433,7 @@ public final class BaselineGCMapIterator extends GCMapIterator {
     //dynamic bridge's registers already restored by calls to getNextReferenceAddress()
     if (!currentMethod.getDeclaringClass().hasDynamicBridgeAnnotation()) {
       if (VM.TraceStkMaps) VM.sysWriteln("    Update Caller RegisterLocations");
-      Address addr = framePtr.plus(BaselineCompilerImpl.getFrameSize(currentCompiledMethod));
+      Address addr = framePtr.plus(currentCompiledMethod.getFrameSize());
       addr =
           addr.minus((currentCompiledMethod.getLastFloatStackRegister() - FIRST_FLOAT_LOCAL_REGISTER.value() + 1) <<
                      LOG_BYTES_IN_DOUBLE); //skip float registers

--- a/rvm/src/org/jikesrvm/compilers/common/CompiledMethods.java
+++ b/rvm/src/org/jikesrvm/compilers/common/CompiledMethods.java
@@ -22,7 +22,6 @@ import org.jikesrvm.VM;
 import org.jikesrvm.classloader.RVMArray;
 import org.jikesrvm.classloader.RVMMethod;
 import org.jikesrvm.classloader.RVMType;
-import org.jikesrvm.compilers.baseline.BaselineCompiledMethod;
 import org.jikesrvm.compilers.opt.runtimesupport.OptCompiledMethod;
 import org.jikesrvm.jni.JNICompiledMethod;
 import org.jikesrvm.runtime.Magic;
@@ -122,7 +121,12 @@ public class CompiledMethods {
     currentCompiledMethodId++;
     CompiledMethod cm = null;
     if (compilerType == CompiledMethod.BASELINE) {
-      cm = new BaselineCompiledMethod(id, m);
+      if (VM.BuildForIA32) {
+        cm = new org.jikesrvm.compilers.baseline.ia32.ArchBaselineCompiledMethod(id, m);
+      } else {
+        if (VM.VerifyAssertions) VM._assert(VM.BuildForPowerPC);
+        cm = new org.jikesrvm.compilers.baseline.ppc.ArchBaselineCompiledMethod(id, m);
+      }
     } else if (VM.BuildForOptCompiler && compilerType == CompiledMethod.OPT) {
       cm = new OptCompiledMethod(id, m);
     } else if (compilerType == CompiledMethod.JNI) {

--- a/rvm/src/org/jikesrvm/osr/ia32/BaselineExecutionStateExtractor.java
+++ b/rvm/src/org/jikesrvm/osr/ia32/BaselineExecutionStateExtractor.java
@@ -43,7 +43,7 @@ import static org.jikesrvm.runtime.UnboxedSizeConstants.BYTES_IN_ADDRESS;
 
 import org.jikesrvm.VM;
 import org.jikesrvm.classloader.NormalMethod;
-import org.jikesrvm.compilers.baseline.BaselineCompiledMethod;
+import org.jikesrvm.compilers.baseline.ia32.ArchBaselineCompiledMethod;
 import org.jikesrvm.compilers.baseline.ia32.BaselineCompilerImpl;
 import org.jikesrvm.compilers.common.CompiledMethods;
 import org.jikesrvm.osr.BytecodeTraverser;
@@ -115,7 +115,7 @@ public final class BaselineExecutionStateExtractor extends ExecutionStateExtract
       VM._assert(fooCmid == cmid);
     }
 
-    BaselineCompiledMethod fooCM = (BaselineCompiledMethod) CompiledMethods.getCompiledMethod(cmid);
+    ArchBaselineCompiledMethod fooCM = (ArchBaselineCompiledMethod) CompiledMethods.getCompiledMethod(cmid);
 
     NormalMethod fooM = (NormalMethod) fooCM.getMethod();
 
@@ -213,7 +213,7 @@ public final class BaselineExecutionStateExtractor extends ExecutionStateExtract
 
   /* go over local/stack array, and build VariableElement. */
   private static void getVariableValue(byte[] stack, Offset offset, byte[] types,
-                                       BaselineCompiledMethod compiledMethod, boolean kind, ExecutionState state) {
+                                       ArchBaselineCompiledMethod compiledMethod, boolean kind, ExecutionState state) {
     int size = types.length;
     Offset vOffset = offset;
     for (int i = 0; i < size; i++) {

--- a/rvm/src/org/jikesrvm/osr/ppc/BaselineExecutionStateExtractor.java
+++ b/rvm/src/org/jikesrvm/osr/ppc/BaselineExecutionStateExtractor.java
@@ -54,7 +54,7 @@ import static org.jikesrvm.runtime.UnboxedSizeConstants.BYTES_IN_ADDRESS;
 import org.jikesrvm.VM;
 import org.jikesrvm.architecture.AbstractRegisters;
 import org.jikesrvm.classloader.NormalMethod;
-import org.jikesrvm.compilers.baseline.BaselineCompiledMethod;
+import org.jikesrvm.compilers.baseline.ppc.ArchBaselineCompiledMethod;
 import org.jikesrvm.compilers.baseline.ppc.BaselineCompilerImpl;
 import org.jikesrvm.compilers.common.CompiledMethod;
 import org.jikesrvm.compilers.common.CompiledMethods;
@@ -113,7 +113,7 @@ public final class BaselineExecutionStateExtractor extends ExecutionStateExtract
       VM._assert(fooCmid == cmid);
     }
 
-    BaselineCompiledMethod fooCM = (BaselineCompiledMethod) CompiledMethods.getCompiledMethod(cmid);
+    ArchBaselineCompiledMethod fooCM = (ArchBaselineCompiledMethod) CompiledMethods.getCompiledMethod(cmid);
 
     NormalMethod fooM = (NormalMethod) fooCM.getMethod();
 
@@ -196,10 +196,10 @@ public final class BaselineExecutionStateExtractor extends ExecutionStateExtract
     if (cType == CompiledMethod.BASELINE) {
       if (VM.VerifyAssertions) {
         VM._assert(bufCM.getMethod().hasBaselineSaveLSRegistersAnnotation());
-        VM._assert(methFPoff.EQ(tsFromFPoff.plus(BaselineCompilerImpl.getFrameSize((BaselineCompiledMethod) bufCM))));
+        VM._assert(methFPoff.EQ(tsFromFPoff.plus(((ArchBaselineCompiledMethod) bufCM).getFrameSize())));
       }
 
-      Offset currentRegisterLocation = tsFromFPoff.plus(BaselineCompilerImpl.getFrameSize((BaselineCompiledMethod) bufCM));
+      Offset currentRegisterLocation = tsFromFPoff.plus(((ArchBaselineCompiledMethod) bufCM).getFrameSize());
 
       for (int i = LAST_FLOAT_STACK_REGISTER.value(); i >= FIRST_FLOAT_LOCAL_REGISTER.value(); --i) {
         currentRegisterLocation = currentRegisterLocation.minus(BYTES_IN_DOUBLE);
@@ -279,7 +279,7 @@ public final class BaselineExecutionStateExtractor extends ExecutionStateExtract
 
   /** go over local/stack array, and build VariableElement. */
   private static void getVariableValueFromLocations(byte[] stack, Offset methFPoff, byte[] types,
-                                                    BaselineCompiledMethod compiledMethod, boolean kind,
+                                                    ArchBaselineCompiledMethod compiledMethod, boolean kind,
                                                     TempRegisters registers, ExecutionState state) {
     int start = 0;
     if (kind == LOCAL) {
@@ -430,7 +430,7 @@ public final class BaselineExecutionStateExtractor extends ExecutionStateExtract
 
   /* go over local/stack array, and build VariableElement. */
   private static void getVariableValue(byte[] stack, Offset offset, byte[] types,
-                                       BaselineCompiledMethod compiledMethod, boolean kind, ExecutionState state) {
+                                       ArchBaselineCompiledMethod compiledMethod, boolean kind, ExecutionState state) {
     int size = types.length;
     Offset vOffset = offset;
     for (int i = 0; i < size; i++) {

--- a/rvm/src/org/jikesrvm/osr/ppc/CodeInstaller.java
+++ b/rvm/src/org/jikesrvm/osr/ppc/CodeInstaller.java
@@ -27,8 +27,7 @@ import static org.jikesrvm.runtime.UnboxedSizeConstants.BYTES_IN_ADDRESS;
 
 import org.jikesrvm.VM;
 import org.jikesrvm.adaptive.util.AOSLogging;
-import org.jikesrvm.compilers.baseline.BaselineCompiledMethod;
-import org.jikesrvm.compilers.baseline.ppc.BaselineCompilerImpl;
+import org.jikesrvm.compilers.baseline.ppc.ArchBaselineCompiledMethod;
 import org.jikesrvm.compilers.common.CompiledMethod;
 import org.jikesrvm.compilers.common.CompiledMethods;
 import org.jikesrvm.compilers.common.assembler.ppc.Assembler;
@@ -72,8 +71,8 @@ public abstract class CodeInstaller {
     ////// recover saved registers.
     /////////////////////////////////////
     if (cType == CompiledMethod.BASELINE) {
-      BaselineCompiledMethod bcm = (BaselineCompiledMethod) foo;
-      int offset = BaselineCompilerImpl.getFrameSize(bcm);
+      ArchBaselineCompiledMethod bcm = (ArchBaselineCompiledMethod) foo;
+      int offset = bcm.getFrameSize();
       for (int i = bcm.getLastFloatStackRegister(); i >= FIRST_FLOAT_LOCAL_REGISTER.value(); --i) {
         offset -= BYTES_IN_DOUBLE;
         asm.emitLFD(FPR.lookup(i), offset, FP);


### PR DESCRIPTION
… to the respective BaselineCompilerImpl

The ARM port (which will be ready for merging soon) relies on this change, as it uses different functions to access the relevant information, and it doesn't make sense for arm.BaselineCompilerImpl to implement these generic ones.