### PR TITLE
Overriding non-existing methods because of typo

### DIFF
--- a/MMTk/ext/vm/harness/org/mmtk/harness/vm/Memory.java
+++ b/MMTk/ext/vm/harness/org/mmtk/harness/vm/Memory.java
@@ -157,7 +157,7 @@ public class Memory extends org.mmtk.vm.Memory {
   /** {@inheritDoc} */
   @Override
   @Inline
-  public void combinedLoadBarrier() {
+  public void combinedLoadBarriers() {
     Scheduler.yield();
     // Nothing required
   }


### PR DESCRIPTION
cc @Pavlos1 