### PR TITLE
RVM-1170:Correct getChunkMap() caculation

### DIFF
--- a/MMTk/src/org/mmtk/policy/immix/ChunkList.java
+++ b/MMTk/src/org/mmtk/policy/immix/ChunkList.java
@@ -14,6 +14,7 @@ package org.mmtk.policy.immix;
 
 import static org.mmtk.utility.Constants.BYTES_IN_PAGE;
 import static org.mmtk.utility.Constants.LOG_BYTES_IN_ADDRESS;
+import static org.mmtk.utility.Constants.LOG_BYTES_IN_PAGE;
 
 import org.mmtk.plan.Plan;
 import org.mmtk.policy.Space;
@@ -25,7 +26,8 @@ import org.vmmagic.unboxed.AddressArray;
 @Uninterruptible
 public final class ChunkList {
   private static final int LOG_PAGES_IN_CHUNK_MAP_BLOCK = 0;
-  private static final int ENTRIES_IN_CHUNK_MAP_BLOCK = (BYTES_IN_PAGE << LOG_PAGES_IN_CHUNK_MAP_BLOCK) >> LOG_BYTES_IN_ADDRESS;
+  private static final int LOG_ENTRIES_IN_CHUNK_MAP_BLOCK = LOG_BYTES_IN_PAGE + LOG_PAGES_IN_CHUNK_MAP_BLOCK - LOG_BYTES_IN_ADDRESS;
+  private static final int ENTRIES_IN_CHUNK_MAP_BLOCK = 1 << LOG_ENTRIES_IN_CHUNK_MAP_BLOCK;
   private static final int CHUNK_MAP_BLOCKS = 1 << 4;
   private static final int MAX_ENTRIES_IN_CHUNK_MAP = ENTRIES_IN_CHUNK_MAP_BLOCK * CHUNK_MAP_BLOCKS;
   private final AddressArray chunkMap =  AddressArray.create(CHUNK_MAP_BLOCKS);
@@ -88,7 +90,7 @@ public final class ChunkList {
   }
 
   private int getChunkMap(int entry) {
-    return entry & ~(ENTRIES_IN_CHUNK_MAP_BLOCK - 1);
+    return entry >> LOG_ENTRIES_IN_CHUNK_MAP_BLOCK;
   }
 
   private Address getMapAddress(int entry) {

--- a/bin/buildit
+++ b/bin/buildit
@@ -960,7 +960,7 @@ if ($ok && (defined $test_set || defined $test_list)) {
   }
   $configs =~ s/^ //;
 
-  my $test = "$sshTargetCmdT '$shell \" ".
+  my $test = "$sshTargetCmdT \"$shell \\\" ".
           "  cd $targetRoot && ".
           "  mkdir -p $resultdir && ".
           "  rm -rf results/buildit/latest && ".
@@ -1031,7 +1031,7 @@ if ($ok && (defined $test_set || defined $test_list)) {
     }
   }
 
-  $test .= "\"' \n";
+  $test .= "\\\"\" \n";
   print "$test\n";
   if(! $dry_run) {
     system($test);


### PR DESCRIPTION
It turns out that the overflow error was not result from chunkmap was exhausted, but from wrong formula to get map index. This patch fix the formula.