### PR TITLE
Remove reduntant check in SegregatedFreeList.alloc().

### DIFF
--- a/MMTk/src/org/mmtk/utility/alloc/SegregatedFreeList.java
+++ b/MMTk/src/org/mmtk/utility/alloc/SegregatedFreeList.java
@@ -78,11 +78,7 @@ public abstract class SegregatedFreeList<S extends SegregatedFreeListSpace> exte
       freeList.set(sizeClass, cell.loadAddress());
       /* Clear the free list link */
       cell.store(Address.zero());
-      if (alignedBytes != bytes) {
-        /* Ensure aligned as requested. */
-        cell = alignAllocation(cell, align, offset);
-      }
-      return cell;
+      return alignAllocation(cell, align, offset);
     }
     return allocSlow(bytes, align, offset);
   }


### PR DESCRIPTION
It's safe to call alignAllocation() without checking if alignedBytes == bytes, since alignAllocation() handles this situation already.
Also, SegregatedFreeListLocal.allocSlowOnce() and LargeObjectAllocator.alloc() call alignAllocation() directly.